### PR TITLE
Fixed some unreachable code, also fixing a bug.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,20 +15,22 @@ function req(name, relativeTo) {
 	return relativeTo ? relative(name, relativeTo) : require(name);
 }
 
-module.exports = function(preset, modifications) {
+module.exports = function(presetInput, modifications) {
 	modifications = modifications || {};
 	var nameDrops = modifications.nameDrops!==false;
 
-	if (typeof preset==='string') {
-		if (!preset.match(/(^babel-preset-|\/)/)) {
+	var preset;
+
+	if (typeof presetInput==='string') {
+		if (!presetInput.match(/(^babel-preset-|\/)/)) {
 			try {
-				preset = relative.resolve('babel-preset-'+preset);
+				preset = relative.resolve('babel-preset-'+presetInput);
 			} catch(err) {
 				console.log(err);
 			}
 		}
 		if (!preset) {
-			preset = require.resolve(preset);
+			preset = require.resolve(presetInput);
 		}
 	}
 


### PR DESCRIPTION
When modify-babel-preset was a dependency of another module defining a
preset,

Given the following dependency structure:
- main
  - babel-preset-my-preset
    - modify-babel-preset
    - babel-preset-es2015

If I wanted my preset to extend the es2015 preset, it would have to be
installed as a dependency of "main", because the code designed to handle
this was unreachable due to reuse of a variable name. I expected that I
would only need to install the one preset, instead of installed the
preset to be extended as well.

This renames the variable so that the unreachable code is reachable.
