### PR TITLE
Fix getModuleName to work on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var getFlattenedPlugins = require('./lib/flatten');
 
 // strip a nested module path + filename down to just the innermost module's (file)name
 function getModuleName(path) {
-	return path.replace(/(?:..\/)*(?:(?:.+[\\/])?node_modules[\\/]|[\\/]|\.\.[\\/])((@[^\\/]+[\\/])?[^\\/]+)([\\/].*)?$/g, '$1');
+	return path.replace(/(?:..[\\/])*(?:(?:.+[\\/])?node_modules[\\/]|[\\/]|\.\.[\\/])((@[^\\/]+[\\/])?[^\\/]+)([\\/].*)?$/g, '$1');
 }
 
 


### PR DESCRIPTION
Small change that fixes generating modules name when using on windows machine.
Without this, wrong module name is provided and `indexOf` method cannot find proper plugin to modify. 
