### PR TITLE
Fixing call to 'require-relative'.resolve()

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = function(presetInput, modifications) {
 	if (typeof presetInput==='string') {
 		if (!presetInput.match(/(^babel-preset-|[\\/])/)) {
 			try {
-				preset = relative.resolve('babel-preset-'+presetInput);
+				preset = relative.resolve('babel-preset-'+presetInput, __dirname);
 			} catch(err) {
 				console.log(err);
 			}


### PR DESCRIPTION
By default, the require-relative library falls back to process.cwd() when no directory is provided. This fix allows modify-babel-preset to be called from any working directory by providing __dirname as the directory.

https://github.com/developit/modify-babel-preset/issues/9
